### PR TITLE
make configurable traits local to JupyterSQLiteYStore

### DIFF
--- a/jupyter_server_ydoc/app.py
+++ b/jupyter_server_ydoc/app.py
@@ -6,8 +6,8 @@ try:
 except ModuleNotFoundError:
     raise ModuleNotFoundError("Jupyter Server must be installed to use this extension.")
 
-from traitlets import Float, Int, Type, Unicode, observe
-from ypy_websocket.ystore import BaseYStore, SQLiteYStore  # type: ignore
+from traitlets import Float, Int, Type
+from ypy_websocket.ystore import BaseYStore  # type: ignore
 
 from .handlers import JupyterSQLiteYStore, YDocRoomIdHandler, YDocWebSocketHandler
 
@@ -48,39 +48,6 @@ class YDocExtension(ExtensionApp):
         which stores Y updates in a '.jupyter_ystore.db' SQLite database in the current
         directory, and clears history every 24 hours.""",
     )
-
-    sqlite_ystore_db_path = Unicode(
-        ".jupyter_ystore.db",
-        config=True,
-        help="""The path to the YStore database. Defaults to '.jupyter_ystore.db' in the current
-        directory. Only applicable if the YStore is an SQLiteYStore.""",
-    )
-
-    @observe("sqlite_ystore_db_path")
-    def _observe_sqlite_ystore_db_path(self, change):
-        if issubclass(self.ystore_class, SQLiteYStore):
-            self.ystore_class.db_path = change["new"]
-        else:
-            raise RuntimeError(
-                f"ystore_class must be an SQLiteYStore to be able to set sqlite_ystore_db_path, not {self.ystore_class}"
-            )
-
-    sqlite_ystore_document_ttl = Int(
-        None,
-        allow_none=True,
-        config=True,
-        help="""The document time-to-live in seconds. Defaults to None (document history is never
-        cleared). Only applicable if the YStore is an SQLiteYStore.""",
-    )
-
-    @observe("sqlite_ystore_document_ttl")
-    def _observe_sqlite_ystore_document_ttl(self, change):
-        if issubclass(self.ystore_class, SQLiteYStore):
-            self.ystore_class.document_ttl = change["new"]
-        else:
-            raise RuntimeError(
-                f"ystore_class must be an SQLiteYStore to be able to set sqlite_ystore_document_ttl, not {self.ystore_class}"
-            )
 
     def initialize_settings(self):
         self.settings.update(

--- a/jupyter_server_ydoc/handlers.py
+++ b/jupyter_server_ydoc/handlers.py
@@ -35,7 +35,9 @@ class JupyterSQLiteYStoreMetaclass(type(LoggingConfigurable), type(SQLiteYStore)
     pass
 
 
-class JupyterSQLiteYStore(LoggingConfigurable, SQLiteYStore, metaclass=JupyterSQLiteYStoreMetaclass):
+class JupyterSQLiteYStore(
+    LoggingConfigurable, SQLiteYStore, metaclass=JupyterSQLiteYStoreMetaclass
+):
     db_path = Unicode(
         ".jupyter_ystore.db",
         config=True,
@@ -50,9 +52,6 @@ class JupyterSQLiteYStore(LoggingConfigurable, SQLiteYStore, metaclass=JupyterSQ
         help="""The document time-to-live in seconds. Defaults to None (document history is never
         cleared). Only applicable if the YStore is an SQLiteYStore.""",
     )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
 
 class DocumentRoom(YRoom):
@@ -164,7 +163,9 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
         assert file_path is not None
         if file_path != self.room.document.path:
             self.log.debug(
-                "File with ID %s was moved from %s to %s", self.room.document.path, file_path
+                "File with ID %s was moved from %s to %s",
+                self.room.document.path,
+                file_path,
             )
             self.room.document.path = file_path
         return file_format, file_type, file_path
@@ -296,7 +297,8 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
             # filter out message depending on changes
             if skip:
                 self.log.debug(
-                    "Filtered out Y message of type: %s", YMessageType(message_type).name
+                    "Filtered out Y message of type: %s",
+                    YMessageType(message_type).name,
                 )
                 return skip
         self._message_queue.put_nowait(message)


### PR DESCRIPTION
@davidbrochart 

This makes the configurable traits local to `JupyterSQLiteYStore`. You can verify functionality by adding logging statements to the base `SQLiteYStore.init_db()` in `ypy-websocket`, and then starting JL with the following commands:

```
jupyter lab --collaborative --JupyterSQLiteYStore.db_path=.jupyter_ystore_asdf.db --JupyterSQLiteYStore.document_ttl=99999
```

The only caveat is that I don't think the configurable traits are actually used in the constructor. IOW, `self.db_path` is not the configured value inside `SQLiteYStore.__init__()`, but rather it is always `.jupyter_ystore.db`. However, I believe this is the existing behavior in your PR anyways.

